### PR TITLE
Cleanup2

### DIFF
--- a/dockerfiles/Dockerfile.ostro
+++ b/dockerfiles/Dockerfile.ostro
@@ -15,7 +15,7 @@ RUN  mkdir -p /ostro/bin && \
      chmod -R a+rwx /ostro
 COPY helpers/runbitbake.py /ostro/bin/runbitbake.py
 COPY helpers/startOstroScript.sh /ostro/bin/startOstroScript.sh
-COPY confs/ostro/ostro.conf /ostro/sample-conf/ostro.conf
+COPY confs/ostro/* /ostro/sample-conf/
 
 RUN   chmod +rx /ostro/bin/runbitbake.py && \
       chmod +rx /ostro/bin/startOstroScript.sh && \

--- a/helpers/startOstroScript.sh
+++ b/helpers/startOstroScript.sh
@@ -31,12 +31,12 @@ chmod a+rw  ${EXTRA_CONF}
 
 # switch into user to build
 sudo  --user ${H_USER} /ostro/bin/runbitbake.py --pokydir $POKY_DIR --extraconf $EXTRA_CONF --extralayers $EXTRA_LAYERS -b $BUILD_DIR -t $*
-echo "copying images to shared folder"
 
 # we need to source the bitbake env in order to use the bitbake script to find the images
 cd ${BUILD_DIR}
-source ${POKY_DIR}/oe-init-build-env >> /dev/null
+source ${POKY_DIR}/oe-init-build-env ${BUILD_DIR} >> /dev/null
 CON_DIR=`bitbake -e | egrep "DEPLOY_DIR_IMAGE\="|tr "\=" " " | tr -d "\""| awk '{print $2}'`
-rsync -a ${CON_DIR} /ostro/ostro-shared/images/ > /dev/null 2>&1
+echo "copying images to shared folder from ${CON_DIR}"
+rsync -a ${CON_DIR}/ /ostro/ostro-shared/images/ > /dev/null 2>&1
 
 


### PR DESCRIPTION
fixes startOstro script to correctly copy over image files.
adds everythng in conf to sampleconf inside the container.
